### PR TITLE
Resize theme_name string

### DIFF
--- a/settings.c
+++ b/settings.c
@@ -618,7 +618,7 @@ settings_parse_cmdline(struct settings *s, int argc, char * const argv[])
 void
 settings_reload_config(struct settings *s)
 {
-	char   theme_name[100];
+	char   theme_name[101];
 	size_t length, linenum = 0;
 	char  *line;
 	FILE  *fin;


### PR DESCRIPTION
Was getting this error running `make`:

```
cc -O2 -pipe  -c -std=c89 -Wall -Wextra -Werror -O2 `pkg-config --cflags pangocairo` settings.c
settings.c:659:49: error: 'sscanf' may overflow; destination buffer in argument 3 has size 100, but the corresponding specifier may require size 101 [-Werror,-Wfortify-source]
                if (1 == sscanf(line, " [%100[-a-zA-Z0-9]] ", theme_name)) {
                                                              ^
1 error generated.
*** Error 1 in /home/bm3719/src/c/oxbar (Makefile:38 'settings.o')
```

I think this is because `sscanf` can return up to 101 bytes (100 characters + `\0`).